### PR TITLE
Improve Love interaction feedback

### DIFF
--- a/common/src/main/java/com/iamkaf/valentine/events/OnPat.java
+++ b/common/src/main/java/com/iamkaf/valentine/events/OnPat.java
@@ -51,7 +51,7 @@ public class OnPat {
                     1f,
                     serverLevel.getRandom().nextLong()
             ));
-            return InteractionResult.CONSUME;
+            return InteractionResult.SUCCESS;
         }
 
         return InteractionResult.PASS;

--- a/common/src/main/java/com/iamkaf/valentine/item/custom/Love.java
+++ b/common/src/main/java/com/iamkaf/valentine/item/custom/Love.java
@@ -1,6 +1,11 @@
 package com.iamkaf.valentine.item.custom;
 
+import com.iamkaf.valentine.Valentine;
 import net.minecraft.core.Holder;
+import net.minecraft.core.Position;
+import net.minecraft.core.dispenser.BlockSource;
+import net.minecraft.core.dispenser.DefaultDispenseItemBehavior;
+import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.network.protocol.game.ClientboundSoundPacket;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
@@ -11,6 +16,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.DispenserBlock;
 import org.jetbrains.annotations.NotNull;
 
 import static com.iamkaf.valentine.events.OnPat.patVFX;
@@ -18,6 +24,28 @@ import static com.iamkaf.valentine.events.OnPat.patVFX;
 public class Love extends Item {
     public Love(Properties properties) {
         super(properties);
+    }
+
+    public static void registerDispenseBehavior() {
+        DispenserBlock.registerBehavior(Valentine.Items.LOVE.get(), new DefaultDispenseItemBehavior() {
+            @Override
+            protected ItemStack execute(BlockSource source, ItemStack stack) {
+                Position position = DispenserBlock.getDispensePosition(source);
+                source.level().sendParticles(
+                        ParticleTypes.HEART,
+                        position.x(),
+                        position.y(),
+                        position.z(),
+                        20,
+                        0.5,
+                        0.2,
+                        0.5,
+                        0.8d
+                );
+                stack.shrink(1);
+                return stack;
+            }
+        });
     }
 
     @Override

--- a/fabric/src/main/java/com/iamkaf/valentine/fabric/ValentineFabric.java
+++ b/fabric/src/main/java/com/iamkaf/valentine/fabric/ValentineFabric.java
@@ -3,6 +3,7 @@ package com.iamkaf.valentine.fabric;
 import com.iamkaf.valentine.Valentine;
 import com.iamkaf.valentine.Register;
 import com.iamkaf.valentine.block.CottonCandyCropBlock;
+import com.iamkaf.valentine.item.custom.Love;
 import com.iamkaf.valentine.worldgen.WorldGen;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
@@ -17,6 +18,7 @@ public final class ValentineFabric implements ModInitializer {
     @Override
     public void onInitialize() {
         Valentine.init();
+        Love.registerDispenseBehavior();
         Registry.register(BuiltInRegistries.BLOCK_TYPE, Valentine.resource("cotton_candy_crop"), CottonCandyCropBlock.CODEC);
         registerPotionRecipes();
         registerCompostables();

--- a/forge/src/main/java/com/iamkaf/valentine/forge/ValentineForge.java
+++ b/forge/src/main/java/com/iamkaf/valentine/forge/ValentineForge.java
@@ -1,13 +1,22 @@
 package com.iamkaf.valentine.forge;
 
 import com.iamkaf.valentine.Valentine;
+import com.iamkaf.valentine.item.custom.Love;
+import net.minecraft.core.registries.Registries;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLLoader;
+import net.minecraftforge.registries.RegisterEvent;
 
 @Mod(Valentine.MOD_ID)
 public final class ValentineForge {
-    public ValentineForge() {
+    public ValentineForge(FMLJavaModLoadingContext context) {
         Valentine.init();
+        RegisterEvent.getBus(context.getModBusGroup()).addListener(event -> {
+            if (event.getRegistryKey().equals(Registries.ITEM)) {
+                Love.registerDispenseBehavior();
+            }
+        });
         if (FMLLoader.getDist().isClient()) {
             ValentineForgeClient.init();
         }

--- a/neoforge/src/main/java/com/iamkaf/valentine/neoforge/ValentineNeoForge.java
+++ b/neoforge/src/main/java/com/iamkaf/valentine/neoforge/ValentineNeoForge.java
@@ -1,12 +1,20 @@
 package com.iamkaf.valentine.neoforge;
 
 import com.iamkaf.valentine.Valentine;
+import com.iamkaf.valentine.item.custom.Love;
+import net.minecraft.core.registries.Registries;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.registries.RegisterEvent;
 
 @Mod(Valentine.MOD_ID)
 public final class ValentineNeoForge {
     public ValentineNeoForge(IEventBus eBussy) {
         Valentine.init();
+        eBussy.addListener((RegisterEvent event) -> {
+            if (event.getRegistryKey().equals(Registries.ITEM)) {
+                Love.registerDispenseBehavior();
+            }
+        });
     }
 }


### PR DESCRIPTION
Makes successful friend petting play the main-hand swing animation as immediate feedback.\n\nDispensers can also activate Love, consuming one item to release a burst of hearts in front of the dispenser while retaining the normal dispense sound and animation.